### PR TITLE
fix: resolve all golangci-lint issues

### DIFF
--- a/core/cache/client.go
+++ b/core/cache/client.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 )
@@ -39,7 +40,7 @@ func (c *cache) Get(ctx context.Context, key string, target any) error {
 	}
 
 	if c.options.decoder == nil {
-		return fmt.Errorf("cache: no decoder configured")
+		return errors.New("cache: no decoder configured")
 	}
 
 	if c.options.useMutex {
@@ -80,7 +81,7 @@ func (c *cache) Set(ctx context.Context, item Item) error {
 	}
 
 	if c.options.encoder == nil {
-		return fmt.Errorf("cache: no encoder configured")
+		return errors.New("cache: no encoder configured")
 	}
 
 	val, err := c.options.encoder(item.Value)

--- a/core/cache/memory.go
+++ b/core/cache/memory.go
@@ -25,8 +25,7 @@ func (i *inMemoryCache) Set(ctx context.Context, item Item) error {
 
 	if item.ExpiresIn > 0 {
 		time.AfterFunc(item.ExpiresIn, func() {
-			//nolint:errcheck
-			i.Delete(context.TODO(), item.Key)
+			_ = i.Delete(context.TODO(), item.Key)
 		})
 	}
 

--- a/core/cache/resolver.go
+++ b/core/cache/resolver.go
@@ -2,7 +2,7 @@ package cache
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"time"
 )
 
@@ -129,7 +129,7 @@ func (r *Resolver[T]) GetOrFetch(ctx context.Context, fallback Handler[T]) (T, e
 	}
 
 	if fallback == nil {
-		return target, fmt.Errorf("cache: no fallback provided")
+		return target, errors.New("cache: no fallback provided")
 	}
 
 	// Resolve using fallback if cache miss or error

--- a/core/conf/factory.go
+++ b/core/conf/factory.go
@@ -57,7 +57,7 @@ func (v *valueMap) GetBytes(key string) []byte {
 func (v *valueMap) MustGetInt(key string) int {
 	value, ok := v.get(key)
 	if !ok {
-		panic(fmt.Sprintf("key not found: %s", key))
+		panic("key not found: " + key)
 	}
 	return convertToInt(value)
 }
@@ -67,7 +67,7 @@ func (v *valueMap) MustGetInt(key string) int {
 func (v *valueMap) MustGetBool(key string) bool {
 	value, ok := v.get(key)
 	if !ok {
-		panic(fmt.Sprintf("key not found: %s", key))
+		panic("key not found: " + key)
 	}
 	return convertToBool(value)
 }
@@ -77,7 +77,7 @@ func (v *valueMap) MustGetBool(key string) bool {
 func (v *valueMap) MustGetString(key string) string {
 	value, ok := v.get(key)
 	if !ok {
-		panic(fmt.Sprintf("key not found: %s", key))
+		panic("key not found: " + key)
 	}
 	return value
 }
@@ -87,7 +87,7 @@ func (v *valueMap) MustGetString(key string) string {
 func (v *valueMap) MustGetBytes(key string) []byte {
 	value, ok := v.get(key)
 	if !ok {
-		panic(fmt.Sprintf("key not found: %s", key))
+		panic("key not found: " + key)
 	}
 	return []byte(value)
 }

--- a/core/job/orchestrator.go
+++ b/core/job/orchestrator.go
@@ -62,9 +62,7 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 				continue
 			}
 
-			o.workers.Add(1)
-			go func() {
-				defer o.workers.Done()
+			o.workers.Go(func() {
 				if o.stopping.Load() {
 					return
 				}
@@ -76,7 +74,7 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 				if err := o.Repo.WithTransaction(ctx, txFn); err != nil {
 					logger.Of(ctx).ErrorS("Failed to process jobs", logger.WithValue("error", err))
 				}
-			}()
+			})
 		}
 	}
 }

--- a/core/logger/interface.go
+++ b/core/logger/interface.go
@@ -1,3 +1,4 @@
+// Package logger provides a structured logging abstraction with multiple severity levels and pluggable providers.
 package logger
 
 // Logger defines the interface for logging operations at different severity levels.

--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -23,7 +23,10 @@ func New(opts ...Option) *logger {
 	// If global logger exists, inherit its configuration
 	if global != nil {
 		if globalLogger, ok := global.logger.(*logger); ok {
-			l.cfg = append(globalLogger.cfg, opts...)
+			merged := make([]Option, 0, len(globalLogger.cfg)+len(opts))
+			merged = append(merged, globalLogger.cfg...)
+			merged = append(merged, opts...)
+			l.cfg = merged
 		}
 	}
 
@@ -38,7 +41,7 @@ func New(opts ...Option) *logger {
 // With creates a new logger instance with additional options appended to existing ones
 func (l *logger) With(opts ...Option) Logger {
 	// Create a new slice to avoid modifying the original
-	newCfg := make([]Option, len(l.cfg))
+	newCfg := make([]Option, len(l.cfg), len(l.cfg)+len(opts))
 	copy(newCfg, l.cfg)
 	newCfg = append(newCfg, opts...)
 

--- a/core/logger/std.go
+++ b/core/logger/std.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"fmt"
 	"log"
+	"strings"
 )
 
 // consoleWriter implements the Provider interface for console-based logging
@@ -22,8 +23,9 @@ func initConsoleLogger() Provider {
 func (cw *consoleWriter) Write(rank Level, content string, modifiers ...Option) {
 	config := NewConfig(modifiers...)
 
-	formatStr := "[%s] text=%s"
-	values := []interface{}{
+	var sb strings.Builder
+	sb.WriteString("[%s] text=%s")
+	values := []any{
 		rank.String(),
 		content,
 	}
@@ -31,22 +33,22 @@ func (cw *consoleWriter) Write(rank Level, content string, modifiers ...Option) 
 	for attr, val := range config.Attributes {
 		switch v := val.(type) {
 		case string:
-			formatStr += fmt.Sprintf(" %s=%s", attr, v)
+			sb.WriteString(fmt.Sprintf(" %s=%s", attr, v))
 		case int, int8, int16, int32, int64:
-			formatStr += fmt.Sprintf(" %s=%d", attr, v)
+			sb.WriteString(fmt.Sprintf(" %s=%d", attr, v))
 		case uint, uint8, uint16, uint32, uint64:
-			formatStr += fmt.Sprintf(" %s=%d", attr, v)
+			sb.WriteString(fmt.Sprintf(" %s=%d", attr, v))
 		// TODO: Consider handling complex nested structures
 		default:
 			// Ignore unsupported types
 		}
 	}
 
-	log.Printf(formatStr, values...)
+	log.Printf(sb.String(), values...)
 }
 
 // OutputFormatted writes a formatted message with level prefix
-func (cw *consoleWriter) WriteF(rank Level, layout string, params ...interface{}) {
+func (cw *consoleWriter) WriteF(rank Level, layout string, params ...any) {
 	entry := fmt.Sprintf("[%s] - %s", rank.String(), layout)
 	if len(params) > 0 {
 		log.Printf(entry, params...)

--- a/core/worker/worker.go
+++ b/core/worker/worker.go
@@ -17,7 +17,7 @@ type TaskProvider interface {
 	Execute(context.Context) error
 }
 
-// Optional lifecycle hooks
+// OnStarter is an optional lifecycle hook for workers that need initialization on start.
 type OnStarter interface {
 	OnStart(context.Context) error
 }

--- a/plugin/broker/sns/publisher_mapper.go
+++ b/plugin/broker/sns/publisher_mapper.go
@@ -30,10 +30,7 @@ func mapToPublishEntries(encoder broker.Encoder, messages ...broker.Message) ([]
 			return nil, err
 		}
 
-		entry, err := mapToPublishEntry(string(payload), message.Attributes())
-		if err != nil {
-			return nil, err
-		}
+		entry := mapToPublishEntry(string(payload), message.Attributes())
 
 		entries = append(entries, entry)
 	}
@@ -41,7 +38,7 @@ func mapToPublishEntries(encoder broker.Encoder, messages ...broker.Message) ([]
 	return entries, nil
 }
 
-func mapToPublishEntry(body string, attributes broker.Attributes) (types.PublishBatchRequestEntry, error) {
+func mapToPublishEntry(body string, attributes broker.Attributes) types.PublishBatchRequestEntry {
 	res := types.PublishBatchRequestEntry{
 		Id:                aws.String(uuid.NewString()),
 		Message:           aws.String(body),
@@ -57,5 +54,5 @@ func mapToPublishEntry(body string, attributes broker.Attributes) (types.Publish
 		}
 	}
 
-	return res, nil
+	return res
 }

--- a/plugin/broker/subscriber/handler.go
+++ b/plugin/broker/subscriber/handler.go
@@ -41,7 +41,7 @@ func (h *Handler[T]) Start(ctx context.Context, workerCount int) error {
 	}
 
 	h.wg.Add(workerCount)
-	for i := 0; i < workerCount; i++ {
+	for range workerCount {
 		go h.worker(ctx)
 	}
 

--- a/plugin/cache/redis/options.go
+++ b/plugin/cache/redis/options.go
@@ -48,29 +48,29 @@ func WithDB(db int) Option {
 // WithMaxRetry sets the maximum number of retry attempts option.
 func WithMaxRetry(attempts uint) Option {
 	return func(o *options) {
-		o.redisOptions.MaxRetries = int(attempts)
+		o.redisOptions.MaxRetries = int(attempts) //nolint:gosec // retry attempts are inherently small values
 	}
 }
 
 // WithRetryBackoff sets the retry backoff time range options.
-func WithRetryBackoff(min, max time.Duration) Option {
+func WithRetryBackoff(minBackoff, maxBackoff time.Duration) Option {
 	return func(o *options) {
-		o.redisOptions.MinRetryBackoff = min
-		o.redisOptions.MaxRetryBackoff = max
+		o.redisOptions.MinRetryBackoff = minBackoff
+		o.redisOptions.MaxRetryBackoff = maxBackoff
 	}
 }
 
 // WithPoolSize sets the connection pool size option.
 func WithPoolSize(size uint) Option {
 	return func(o *options) {
-		o.redisOptions.PoolSize = int(size)
+		o.redisOptions.PoolSize = int(size) //nolint:gosec // pool size is inherently a small value
 	}
 }
 
 // WithMinIdleConns sets the minimum number of idle connections option.
 func WithMinIdleConns(size uint) Option {
 	return func(o *options) {
-		o.redisOptions.MinIdleConns = int(size)
+		o.redisOptions.MinIdleConns = int(size) //nolint:gosec // idle conns is inherently a small value
 	}
 }
 

--- a/plugin/cache/redis/provider.go
+++ b/plugin/cache/redis/provider.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 
 	"github.com/aawadallak/go-core-kit/core/cache"
 	"github.com/redis/go-redis/v9"
@@ -16,7 +17,7 @@ var _ cache.Provider = (*cacheProvider)(nil)
 
 func (c *cacheProvider) Get(ctx context.Context, key string) ([]byte, error) {
 	cmd := c.client.Get(ctx, key)
-	if cmd.Err() == redis.Nil {
+	if errors.Is(cmd.Err(), redis.Nil) {
 		return nil, cache.ErrKeyNotFound
 	}
 	if cmd.Err() != nil {

--- a/plugin/conf/ssm/factory.go
+++ b/plugin/conf/ssm/factory.go
@@ -48,7 +48,7 @@ func (p *provider) Scan(fn conf.ScanFunc) {
 	}
 }
 
-// Load fetches parameters from SSM and updates the local data store
+// Load fetches parameters from SSM and updates the local data store.
 func (p *provider) Load(ctx context.Context, others []conf.Provider) error {
 	parameters := findSSMParameterReferences(others)
 	if len(parameters) == 0 {
@@ -57,10 +57,7 @@ func (p *provider) Load(ctx context.Context, others []conf.Provider) error {
 
 	// Process secrets in batches
 	for i := 0; i < len(parameters); i += maxParamsPerRequest {
-		end := i + maxParamsPerRequest
-		if end > len(parameters) {
-			end = len(parameters)
-		}
+		end := min(i+maxParamsPerRequest, len(parameters))
 
 		batch := parameters[i:end]
 		params := make([]string, len(batch))

--- a/plugin/conf/ssm/params.go
+++ b/plugin/conf/ssm/params.go
@@ -42,8 +42,8 @@ func findSSMParameterReferences(providers []conf.Provider) []ssmParameter {
 // fetchSSMParameters retrieves parameter values from AWS SSM using the provided parameter names.
 // It fetches the parameters with decryption enabled and stores them in the provider's data map.
 // Returns an error if the parameters cannot be retrieved or if any parameters are invalid.
-func (s *provider) fetchSSMParameters(ctx context.Context, parameterNames []string) error {
-	res, err := s.client.GetParameters(ctx, &ssm.GetParametersInput{
+func (p *provider) fetchSSMParameters(ctx context.Context, parameterNames []string) error {
+	res, err := p.client.GetParameters(ctx, &ssm.GetParametersInput{
 		Names:          parameterNames,
 		WithDecryption: aws.Bool(true),
 	})
@@ -56,7 +56,7 @@ func (s *provider) fetchSSMParameters(ctx context.Context, parameterNames []stri
 	}
 
 	for _, param := range res.Parameters {
-		s.data[*param.Name] = *param.Value
+		p.data[*param.Name] = *param.Value
 	}
 
 	return nil

--- a/plugin/event/outbox/publisher.go
+++ b/plugin/event/outbox/publisher.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/aawadallak/go-core-kit/pkg/common"
 	cevent "github.com/aawadallak/go-core-kit/core/event"
+	"github.com/aawadallak/go-core-kit/pkg/common"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/trace"
 )

--- a/plugin/event/outbox/worker.go
+++ b/plugin/event/outbox/worker.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/aawadallak/go-core-kit/core/logger"
 	cevent "github.com/aawadallak/go-core-kit/core/event"
+	"github.com/aawadallak/go-core-kit/core/logger"
 )
 
 const (

--- a/plugin/event/publisher.go
+++ b/plugin/event/publisher.go
@@ -4,8 +4,8 @@ package event
 import (
 	"context"
 
-	"github.com/aawadallak/go-core-kit/pkg/common"
 	cevent "github.com/aawadallak/go-core-kit/core/event"
+	"github.com/aawadallak/go-core-kit/pkg/common"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/plugin/logger/slogx/factory.go
+++ b/plugin/logger/slogx/factory.go
@@ -49,12 +49,12 @@ func NewProvider(opts ...Option) (logger.Provider, error) {
 
 	// Configure slog handler with JSON output and level
 	handler := slog.NewJSONHandler(os.Stdout, lOptions)
-	logger := slog.New(handler)
+	slogLogger := slog.New(handler)
 
-	slog.SetDefault(logger)
+	slog.SetDefault(slogLogger)
 
 	return &SlogProvider{
-		logger: logger,
+		logger: slogLogger,
 		level:  logLevel,
 	}, nil
 }

--- a/plugin/logger/zapx/factory.go
+++ b/plugin/logger/zapx/factory.go
@@ -18,7 +18,7 @@ type ZapProvider struct {
 // Ensure ZapProvider implements the Provider interface.
 var _ logger.Provider = (*ZapProvider)(nil)
 
-// defaultZapProvider creates a new ZapProvider with the default configuration.
+// NewProvider creates a new ZapProvider with the default configuration.
 func NewProvider(opts ...Option) (logger.Provider, error) {
 	options := newOptions(opts...)
 
@@ -54,14 +54,14 @@ func NewProvider(opts ...Option) (logger.Provider, error) {
 
 	lOptions := []zap.Option{}
 
-	logger, err := cfg.Build(lOptions...)
+	zapLogger, err := cfg.Build(lOptions...)
 	if err != nil {
 		return nil, err
 	}
 
-	zap.ReplaceGlobals(logger)
+	zap.ReplaceGlobals(zapLogger)
 
-	return &ZapProvider{logger: logger, level: logLevel, options: options}, nil
+	return &ZapProvider{logger: zapLogger, level: logLevel, options: options}, nil
 }
 
 // Write logs a message with the specified level and attributes.

--- a/plugin/logger/zapx/options.go
+++ b/plugin/logger/zapx/options.go
@@ -7,7 +7,7 @@ type options struct {
 
 type Option func(*options)
 
-// WithAddCaller enables caller information in the log output
+// WithEnableCaller enables caller information in the log output.
 func WithEnableCaller() Option {
 	return func(o *options) {
 		o.enableCaller = true

--- a/plugin/rest/response.go
+++ b/plugin/rest/response.go
@@ -85,7 +85,7 @@ func New(w http.ResponseWriter, status int, opts ...ResponseOption) error {
 	return err
 }
 
-// Success response helpers
+// NewStatusOK creates a response with HTTP 200 status.
 func NewStatusOK(w http.ResponseWriter, opts ...ResponseOption) error {
 	return New(w, http.StatusOK, opts...)
 }
@@ -140,7 +140,7 @@ func newErrorResponse(w http.ResponseWriter, status int, cause error, opts ...Er
 	return New(w, status, rOpt...)
 }
 
-// Error response helpers
+// NewStatusBadRequest creates a response with HTTP 400 status.
 func NewStatusBadRequest(w http.ResponseWriter, cause error, opts ...ErrorResponseOption) error {
 	return newErrorResponse(w, http.StatusBadRequest, cause, opts...)
 }

--- a/tests/integration/cache/redis_test.go
+++ b/tests/integration/cache/redis_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aawadallak/go-core-kit/core/cache"
 	"github.com/aawadallak/go-core-kit/plugin/cache/redis"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRedisProvider(t *testing.T) {
@@ -25,7 +26,7 @@ func TestRedisProvider(t *testing.T) {
 		setup         func(t *testing.T)
 		operation     func(t *testing.T)
 		expectedError error
-		expectedValue interface{}
+		expectedValue any
 		checkResult   bool
 	}{
 		{
@@ -67,7 +68,7 @@ func TestRedisProvider(t *testing.T) {
 			},
 			operation: func(t *testing.T) {
 				err := provider.Delete(ctx, "delete-key")
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				_, err = provider.Get(ctx, "delete-key")
 				assert.ErrorIs(t, err, cache.ErrKeyNotFound)
 			},
@@ -99,7 +100,7 @@ func TestRedisProviderWithCache(t *testing.T) {
 	provider, err := redis.NewProvider(ctx,
 		redis.WithAddress("localhost:6379"),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer provider.Close(ctx)
 
 	c := cache.New(provider,
@@ -185,7 +186,7 @@ func TestRedisProviderWithCacheResolver_Get(t *testing.T) {
 					ExpiresIn: time.Minute,
 				}
 				err := c.Set(ctx, cItem)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				return cache.NewResolver("test-key-hit",
 					cache.WithCache[Sample](c),
 					cache.WithExpiration[Sample](time.Minute),


### PR DESCRIPTION
## Summary
Fixes all 39 golangci-lint issues flagged by CI:

- **errorlint** — Use `errors.Is` instead of `==` for error comparison
- **gocritic** — Fix `appendAssign`, `builtinShadow` (`min` param), `importShadow` (`logger` var)
- **gofmt** — Format event plugin files
- **gosec** — Handle ignored errors, annotate safe uint→int casts
- **intrange** — Use `for range count` (Go 1.22+)
- **modernize** — `interface{}` → `any`, `string +=` → `strings.Builder`, `WaitGroup.Go`
- **perfsprint** — `fmt.Errorf` → `errors.New`, `fmt.Sprintf` → string concat
- **prealloc** — Preallocate slice with known capacity
- **staticcheck** — Fix package/exported comments (ST1000, ST1016, ST1020, ST1021)
- **testifylint** — `assert.NoError` → `require.NoError` for error checks
- **unparam** — Remove always-nil error return from `mapToPublishEntry`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./core/... ./plugin/txm/... ./pkg/...` passes
- [ ] CI lint job passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)