### PR TITLE
refactor: decouple eventbroker from NATS JetStream via Transport interface (#20)

### DIFF
--- a/plugin/broker/natsjetstream/event_transport.go
+++ b/plugin/broker/natsjetstream/event_transport.go
@@ -1,0 +1,240 @@
+package natsjetstream
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/aawadallak/go-core-kit/plugin/event/eventbroker"
+)
+
+// Compile-time interface checks.
+var (
+	_ eventbroker.Transport         = (*EventTransport)(nil)
+	_ eventbroker.ConsumerTransport = (*EventTransport)(nil)
+)
+
+// EventTransportConfig holds the configuration for creating an EventTransport.
+type EventTransportConfig struct {
+	Endpoint   string
+	StreamName string
+	Subjects   []string
+}
+
+// EventTransport implements eventbroker.Transport and eventbroker.ConsumerTransport
+// on top of NATS JetStream.
+type EventTransport struct {
+	conn *nats.Conn
+	js   jetstream.JetStream
+}
+
+// NewEventTransport creates a new EventTransport that connects to NATS and
+// ensures the given stream exists.
+func NewEventTransport(ctx context.Context, cfg EventTransportConfig) (*EventTransport, error) {
+	conn, err := nats.Connect(cfg.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	js, err := jetstream.New(conn)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	if cfg.StreamName != "" && len(cfg.Subjects) > 0 {
+		if err := ensureStream(ctx, js, cfg.StreamName, cfg.Subjects); err != nil {
+			conn.Close()
+			return nil, err
+		}
+	}
+
+	return &EventTransport{conn: conn, js: js}, nil
+}
+
+// NewEventTransportFromJetStream creates an EventTransport from an existing
+// JetStream handle. Useful when the caller already manages the NATS connection.
+func NewEventTransportFromJetStream(js jetstream.JetStream) *EventTransport {
+	return &EventTransport{js: js}
+}
+
+// Publish implements eventbroker.Transport.
+func (t *EventTransport) Publish(ctx context.Context, subject string, data []byte) error {
+	_, err := t.js.Publish(ctx, subject, data)
+	return err
+}
+
+// Subscribe implements eventbroker.ConsumerTransport.
+func (t *EventTransport) Subscribe(
+	ctx context.Context,
+	cfg eventbroker.ConsumerSubscriptionConfig,
+	handler func(ctx context.Context, data []byte) error,
+) (eventbroker.Subscription, error) {
+	maxDeliver := cfg.MaxDeliver
+	if maxDeliver <= 0 {
+		maxDeliver = 5
+	}
+	ackWait := 30 * time.Second
+	if cfg.AckWait > 0 {
+		ackWait = time.Duration(cfg.AckWait) * time.Second
+	}
+	fetchMaxWait := 1 * time.Second
+	if cfg.FetchMaxWait > 0 {
+		fetchMaxWait = time.Duration(cfg.FetchMaxWait) * time.Second
+	}
+
+	if err := ensureStream(ctx, t.js, cfg.StreamName, []string{cfg.Subject}); err != nil {
+		return nil, err
+	}
+	if cfg.DLQStreamName != "" && cfg.DLQSubject != "" {
+		if err := ensureStream(ctx, t.js, cfg.DLQStreamName, []string{cfg.DLQSubject}); err != nil {
+			return nil, err
+		}
+	}
+
+	stream, err := t.js.Stream(ctx, cfg.StreamName)
+	if err != nil {
+		return nil, err
+	}
+
+	consumer, err := stream.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+		Durable:       cfg.DurableName,
+		AckPolicy:     jetstream.AckExplicitPolicy,
+		AckWait:       ackWait,
+		MaxDeliver:    maxDeliver,
+		FilterSubject: cfg.Subject,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &jsSubscription{
+		js:           t.js,
+		consumer:     consumer,
+		handler:      handler,
+		fetchMaxWait: fetchMaxWait,
+		dlqSubject:   cfg.DLQSubject,
+		hasDLQ:       cfg.DLQStreamName != "" && cfg.DLQSubject != "",
+		closeCh:      make(chan struct{}),
+	}, nil
+}
+
+// Close closes the underlying NATS connection, if owned by this transport.
+func (t *EventTransport) Close() error {
+	if t.conn == nil {
+		return nil
+	}
+	t.conn.Close()
+	return nil
+}
+
+// jsSubscription implements eventbroker.Subscription for NATS JetStream.
+type jsSubscription struct {
+	js           jetstream.JetStream
+	consumer     jetstream.Consumer
+	handler      func(ctx context.Context, data []byte) error
+	fetchMaxWait time.Duration
+	dlqSubject   string
+	hasDLQ       bool
+	closed       atomic.Bool
+	closeCh      chan struct{}
+	wg           sync.WaitGroup
+	closeErr     error
+	closeMux     sync.Mutex
+	closeOnce    sync.Once
+}
+
+func (s *jsSubscription) Start(ctx context.Context) {
+	for {
+		if s.shouldStop(ctx) {
+			return
+		}
+
+		msgs, err := s.consumer.Fetch(1, jetstream.FetchMaxWait(s.fetchMaxWait))
+		if err != nil {
+			if s.shouldStop(ctx) {
+				return
+			}
+			continue
+		}
+
+		for msg := range msgs.Messages() {
+			s.wg.Add(1)
+			func(m jetstream.Msg) {
+				defer s.wg.Done()
+				if err := s.handleMessage(ctx, m); err != nil {
+					log.Println(err)
+				}
+			}(msg)
+		}
+	}
+}
+
+func (s *jsSubscription) shouldStop(ctx context.Context) bool {
+	if ctx.Err() != nil {
+		return true
+	}
+	if s.closed.Load() {
+		return true
+	}
+	select {
+	case <-s.closeCh:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *jsSubscription) handleMessage(ctx context.Context, msg jetstream.Msg) error {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			panicErr := fmt.Errorf("panic while handling message: %v", recovered)
+			log.Println(panicErr)
+
+			if s.hasDLQ {
+				if err := publishDLQ(ctx, s.js, s.dlqSubject, msg.Data(), panicErr.Error()); err != nil {
+					log.Printf("failed to publish panic to DLQ: %v", err)
+				}
+				if err := msg.Ack(); err != nil {
+					log.Printf("failed to ack message after panic: %v", err)
+				}
+				return
+			}
+
+			if err := msg.Nak(); err != nil {
+				log.Printf("failed to nak message after panic: %v", err)
+			}
+		}
+	}()
+
+	if err := s.handler(ctx, msg.Data()); err != nil {
+		if s.hasDLQ {
+			if dlqErr := publishDLQ(ctx, s.js, s.dlqSubject, msg.Data(), err.Error()); dlqErr != nil {
+				log.Printf("failed to publish handler error to DLQ: %v", dlqErr)
+			}
+			return msg.Ack()
+		}
+		return msg.Nak()
+	}
+
+	return msg.Ack()
+}
+
+func (s *jsSubscription) Close() error {
+	s.closeOnce.Do(func() {
+		s.closed.Store(true)
+		close(s.closeCh)
+		s.wg.Wait()
+	})
+
+	s.closeMux.Lock()
+	defer s.closeMux.Unlock()
+	return s.closeErr
+}
+

--- a/plugin/event/eventbroker/consumer.go
+++ b/plugin/event/eventbroker/consumer.go
@@ -3,13 +3,12 @@ package eventbroker
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
 	"unicode"
-
-	brokerjs "github.com/aawadallak/go-core-kit/plugin/broker/natsjetstream"
 )
 
 type HandlerFunc func(ctx context.Context, envelope *Envelope) error
@@ -17,7 +16,6 @@ type HandlerFunc func(ctx context.Context, envelope *Envelope) error
 type ConsumerConfig struct {
 	EventName     string
 	Handler       HandlerFunc
-	Endpoint      string
 	StreamName    string
 	Subject       string
 	DurableName   string
@@ -29,45 +27,56 @@ type ConsumerConfig struct {
 }
 
 type Consumer struct {
-	worker *brokerjs.Worker[Envelope]
+	subscription Subscription
 }
 
-func NewConsumer(ctx context.Context, cfg ConsumerConfig) (*Consumer, error) { //nolint:gocritic // hugeParam
+func NewConsumer(transport ConsumerTransport, cfg ConsumerConfig) (*Consumer, error) { //nolint:gocritic // hugeParam
 	if cfg.Handler == nil {
 		return nil, errors.New("consumer handler is required")
 	}
 
 	cfg.DurableName = normalizeConsumerName(cfg.DurableName)
 
-	wrappedHandler := func(ctx context.Context, envelope *Envelope) error {
+	// rawHandler deserialises the envelope and delegates to the configured handler.
+	rawHandler := func(ctx context.Context, data []byte) error {
+		var envelope Envelope
+		if err := json.Unmarshal(data, &envelope); err != nil {
+			return fmt.Errorf("eventbroker: unmarshal envelope: %w", err)
+		}
+
 		if cfg.EventName != "" && envelope.EventName != cfg.EventName {
-			// Different event type: ack and skip.
+			// Different event type: skip.
 			return nil
 		}
 
-		if err := cfg.Handler(ctx, envelope); err != nil {
+		if err := cfg.Handler(ctx, &envelope); err != nil {
 			return fmt.Errorf("event %s handler failed: %w", envelope.EventName, err)
 		}
 		return nil
 	}
 
-	worker, err := brokerjs.NewWorker(ctx, brokerjs.WorkerConfig[Envelope]{
-		Endpoint:      cfg.Endpoint,
+	subCfg := ConsumerSubscriptionConfig{
 		StreamName:    cfg.StreamName,
 		Subject:       cfg.Subject,
 		DurableName:   cfg.DurableName,
 		DLQStreamName: cfg.DLQStreamName,
 		DLQSubject:    cfg.DLQSubject,
 		MaxDeliver:    cfg.MaxDeliver,
-		AckWait:       cfg.AckWait,
-		FetchMaxWait:  cfg.FetchMaxWait,
-		Handler:       wrappedHandler,
-	})
+	}
+
+	if cfg.AckWait > 0 {
+		subCfg.AckWait = int(cfg.AckWait.Seconds())
+	}
+	if cfg.FetchMaxWait > 0 {
+		subCfg.FetchMaxWait = int(cfg.FetchMaxWait.Seconds())
+	}
+
+	sub, err := transport.Subscribe(context.Background(), subCfg, rawHandler)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Consumer{worker: worker}, nil
+	return &Consumer{subscription: sub}, nil
 }
 
 // NATS JetStream consumer names are strict (letters, digits, '_' and '-').
@@ -93,12 +102,12 @@ func normalizeConsumerName(name string) string {
 }
 
 func (c *Consumer) Start(ctx context.Context) {
-	c.worker.Start(ctx)
+	c.subscription.Start(ctx)
 }
 
 func (c *Consumer) Close() error {
-	if c.worker == nil {
+	if c.subscription == nil {
 		return nil
 	}
-	return c.worker.Close()
+	return c.subscription.Close()
 }

--- a/plugin/event/eventbroker/dispatcher.go
+++ b/plugin/event/eventbroker/dispatcher.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/aawadallak/go-core-kit/core/event"
-	brokerjs "github.com/aawadallak/go-core-kit/plugin/broker/natsjetstream"
 )
 
 type Envelope struct {
@@ -21,29 +20,18 @@ type Envelope struct {
 	SpanID        string          `json:"span_id,omitempty"`
 }
 
-type DispatcherConfig struct {
-	Endpoint   string
-	StreamName string
-	Subject    string
-}
-
 type Dispatcher struct {
-	publisher *brokerjs.Publisher
+	transport Transport
+	subject   string
 }
 
 var _ event.Dispatcher = (*Dispatcher)(nil)
 
-func NewDispatcher(ctx context.Context, cfg DispatcherConfig) (*Dispatcher, error) {
-	publisher, err := brokerjs.NewPublisher(ctx, brokerjs.PublisherConfig{
-		Endpoint:   cfg.Endpoint,
-		StreamName: cfg.StreamName,
-		Subject:    cfg.Subject,
-	})
-	if err != nil {
-		return nil, err
+func NewDispatcher(transport Transport, subject string) *Dispatcher {
+	return &Dispatcher{
+		transport: transport,
+		subject:   subject,
 	}
-
-	return &Dispatcher{publisher: publisher}, nil
 }
 
 func (d *Dispatcher) Dispatch(ctx context.Context, evt *event.Record) error {
@@ -59,12 +47,10 @@ func (d *Dispatcher) Dispatch(ctx context.Context, evt *event.Record) error {
 		SpanID:        evt.SpanID,
 	}
 
-	return d.publisher.Publish(ctx, brokerjs.PublishMessage{Message: env})
-}
-
-func (d *Dispatcher) Close() error {
-	if d.publisher == nil {
-		return nil
+	data, err := json.Marshal(env)
+	if err != nil {
+		return err
 	}
-	return d.publisher.Close()
+
+	return d.transport.Publish(ctx, d.subject, data)
 }

--- a/plugin/event/eventbroker/transport.go
+++ b/plugin/event/eventbroker/transport.go
@@ -1,0 +1,34 @@
+package eventbroker
+
+import "context"
+
+// Transport publishes serialized event envelopes to a subject/topic.
+type Transport interface {
+	Publish(ctx context.Context, subject string, data []byte) error
+}
+
+// ConsumerTransport abstracts the consumption side so that eventbroker
+// does not depend on a concrete broker implementation.
+type ConsumerTransport interface {
+	// Subscribe creates a subscription that delivers raw messages to the handler.
+	// The handler receives the raw bytes; deserialization is done by the caller.
+	Subscribe(ctx context.Context, cfg ConsumerSubscriptionConfig, handler func(ctx context.Context, data []byte) error) (Subscription, error)
+}
+
+// ConsumerSubscriptionConfig carries the parameters needed to create a subscription.
+type ConsumerSubscriptionConfig struct {
+	StreamName    string
+	Subject       string
+	DurableName   string
+	DLQStreamName string
+	DLQSubject    string
+	MaxDeliver    int
+	AckWait       int // seconds
+	FetchMaxWait  int // seconds
+}
+
+// Subscription represents an active subscription that can be started and closed.
+type Subscription interface {
+	Start(ctx context.Context)
+	Close() error
+}

--- a/tests/e2e/eventbroker/eventbroker_test.go
+++ b/tests/e2e/eventbroker/eventbroker_test.go
@@ -1,0 +1,115 @@
+package eventbroker_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aawadallak/go-core-kit/core/event"
+	"github.com/aawadallak/go-core-kit/plugin/event/eventbroker"
+)
+
+// memTransport is an in-memory eventbroker.Transport used for testing.
+type memTransport struct {
+	mu       sync.Mutex
+	messages []struct {
+		Subject string
+		Data    []byte
+	}
+}
+
+func (m *memTransport) Publish(_ context.Context, subject string, data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.messages = append(m.messages, struct {
+		Subject string
+		Data    []byte
+	}{Subject: subject, Data: data})
+	return nil
+}
+
+func (m *memTransport) get(i int) (string, []byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.messages[i].Subject, m.messages[i].Data
+}
+
+func (m *memTransport) len() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.messages)
+}
+
+// testMetadata implements event.Metadata for test purposes.
+type testMetadata struct {
+	UserID string `json:"user_id"`
+}
+
+func (t testMetadata) EventType() string  { return "USER_CREATED" }
+func (t testMetadata) EventVersion() int  { return 1 }
+
+func TestDispatcher_Dispatch(t *testing.T) {
+	transport := &memTransport{}
+	subject := "events.user"
+	dispatcher := eventbroker.NewDispatcher(transport, subject)
+
+	record, err := event.NewRecord(testMetadata{UserID: "u-123"}, event.WithCorrelationID("corr-1"))
+	require.NoError(t, err)
+
+	err = dispatcher.Dispatch(context.Background(), record)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, transport.len())
+
+	gotSubject, data := transport.get(0)
+	assert.Equal(t, subject, gotSubject)
+
+	var env eventbroker.Envelope
+	require.NoError(t, json.Unmarshal(data, &env))
+
+	assert.Equal(t, "USER_CREATED", env.EventName)
+	assert.Equal(t, 1, env.Version)
+	assert.Equal(t, "corr-1", env.CorrelationID)
+	assert.Equal(t, record.ID, env.EventID)
+	assert.False(t, env.OccurredAt.IsZero())
+
+	// Verify the payload round-trips.
+	var meta testMetadata
+	require.NoError(t, json.Unmarshal(env.Payload, &meta))
+	assert.Equal(t, "u-123", meta.UserID)
+}
+
+func TestDispatcher_MultipleEvents(t *testing.T) {
+	transport := &memTransport{}
+	dispatcher := eventbroker.NewDispatcher(transport, "events.multi")
+
+	for i := 0; i < 5; i++ {
+		record, err := event.NewRecord(testMetadata{UserID: "u-multi"})
+		require.NoError(t, err)
+		require.NoError(t, dispatcher.Dispatch(context.Background(), record))
+	}
+
+	assert.Equal(t, 5, transport.len())
+}
+
+func TestDispatcher_PreservesTimestamp(t *testing.T) {
+	transport := &memTransport{}
+	dispatcher := eventbroker.NewDispatcher(transport, "events.ts")
+
+	before := time.Now().UTC().Add(-time.Second)
+
+	record, err := event.NewRecord(testMetadata{UserID: "ts"})
+	require.NoError(t, err)
+	require.NoError(t, dispatcher.Dispatch(context.Background(), record))
+
+	_, data := transport.get(0)
+	var env eventbroker.Envelope
+	require.NoError(t, json.Unmarshal(data, &env))
+
+	assert.True(t, env.OccurredAt.After(before), "OccurredAt should be after test start")
+}


### PR DESCRIPTION
## Summary
- Introduces `Transport` and `ConsumerTransport` interfaces in `plugin/event/eventbroker/`
- Removes hard-coded `plugin/broker/natsjetstream` import from dispatcher and consumer
- Adds `plugin/broker/natsjetstream/event_transport.go` as the JetStream adapter implementing both interfaces
- Adds e2e tests using in-memory transport to verify dispatch without infrastructure

Closes #20

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./tests/e2e/eventbroker/...` passes (3 tests with in-memory transport)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)