### PR TITLE
docs: update README/CHANGELOG and fix all lint issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`pkg/common/request_context.go`** — Transport-agnostic `RequestContext` (RequestID, TraceID, SpanID) with context helpers.
+- **`plugin/cache/msgpack`** — MsgPack encoder/decoder codec for `core/cache` (moved from core to plugin).
+- **`plugin/event/eventbroker/transport.go`** — `Transport` and `ConsumerTransport` interfaces for decoupled event dispatching.
+- **`plugin/broker/natsjetstream/event_transport.go`** — NATS JetStream adapter implementing eventbroker transport interfaces.
+- **`tests/e2e/seal/`** — End-to-end tests with PostgreSQL testcontainer for seal/unseal flow.
+- **`tests/e2e/eventbroker/`** — End-to-end tests for event dispatching with in-memory transport.
+
+### Changed
+
+- **`core/audit`** — `Log` struct is now transport-agnostic: HTTP-specific fields (`Method`, `Endpoint`, `StatusCode`, `IP`, `Signature`) replaced with generic `Action` (string) and `Metadata` (map[string]any). Added `NewHTTPLog()` convenience constructor. **Breaking.**
+- **`plugin/seal`** — All types moved from `core/seal` into `plugin/seal/types.go`. Seal is now a self-contained plugin, not a core abstraction. **Breaking.**
+- **`plugin/event/eventbroker`** — Dispatcher and consumer now accept `Transport`/`ConsumerTransport` interfaces instead of hard-coded NATS JetStream dependency. **Breaking.**
+- **`plugin/event/publisher.go`** and **`plugin/event/outbox/publisher.go`** — Updated to use `common.RequestContext` instead of removed `ActivityContext`.
+
+### Removed
+
+- **`core/seal`** — Moved to `plugin/seal`. Too app-specific for core (embeds GORM Entity, niche use case). **Breaking.**
+- **`core/identity`** — Removed entirely. User profile model tied to multi-tenant SaaS pattern, not a general infrastructure concern. **Breaking.**
+- **`core/cache/codec_msgpack.go`** — Moved to `plugin/cache/msgpack`. External dependency doesn't belong in core. **Breaking** (import path changed).
+- **`pkg/common/activity.go`** — Removed `ActivityContext` (web-specific). Replaced by `RequestContext`. **Breaking.**
+
+---
+
+## [Initial] - 2026-03-27
+
+### Added (from initial migration)
+
 - **`pkg/common`** — Shared foundation types: `BaseError` with typed HTTP errors (`ErrResourceNotFound`, `ErrInternalServer`, `ErrConflict`, etc.), `FailureMode` classification, `Entity` base model with GORM integration and auto UUID, `MustValidateDependencies` for struct validation.
 - **`pkg/core/ptr`** — Generic pointer helpers: `New[T]`, `Now()`, `Safe[T]`.
 - **`core/audit`** — Batching audit log system with configurable providers and flush intervals.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This means your application code depends only on `core/` interfaces. Swap Redis 
 
 | Package | Description |
 |---------|-------------|
-| `pkg/common` | Base entity, typed HTTP errors, failure mode classification, dependency validation |
+| `pkg/common` | Base entity, typed HTTP errors, failure mode classification, request context, dependency validation |
 | `pkg/core/ptr` | Generic pointer helpers: `New[T]`, `Now()`, `Safe[T]` |
 
 ### Core Interfaces (`core/`)
@@ -45,7 +45,7 @@ This means your application code depends only on `core/` interfaces. Swap Redis 
 | Package | Description |
 |---------|-------------|
 | `core/logger` | Structured logging with severity levels and context propagation |
-| `core/cache` | Key-value caching with TTL, codecs (JSON, GZIP, MsgPack), and `Resolver[T]` for cache-or-fetch |
+| `core/cache` | Key-value caching with TTL, codecs (JSON, GZIP), and `Resolver[T]` for cache-or-fetch |
 | `core/broker` | Message publishing and subscribing with pluggable codecs |
 | `core/repository` | Generic `AbstractRepository[T]` and `AbstractPaginatedRepository[T, E]` |
 | `core/conf` | Configuration loading from multiple providers |
@@ -53,11 +53,9 @@ This means your application code depends only on `core/` interfaces. Swap Redis 
 | `core/idem` | Idempotency framework with Manager, Store, Locker, and generic `Handle[T]` |
 | `core/job` | Async job queue with Orchestrator, panic recovery, and graceful shutdown |
 | `core/worker` | Background worker with lifecycle hooks |
-| `core/audit` | Batching audit log system with configurable flush intervals |
+| `core/audit` | Transport-agnostic batching audit log system with generic payload |
 | `core/cipher` | Hashing and verification interface |
 | `core/featureflag` | Feature toggle service with caching and auto-sync |
-| `core/identity` | Request context identity with organization/role support |
-| `core/seal` | Data sealing via signatures with nonce-based replay protection |
 | `core/txm` | Transaction manager interface |
 
 ### Plugin Implementations (`plugin/`)
@@ -67,6 +65,7 @@ This means your application code depends only on `core/` interfaces. Swap Redis 
 | `plugin/logger/zapx` | [Zap](https://github.com/uber-go/zap) | `core/logger` |
 | `plugin/logger/slogx` | `log/slog` | `core/logger` |
 | `plugin/cache/redis` | [go-redis](https://github.com/redis/go-redis) | `core/cache` |
+| `plugin/cache/msgpack` | [msgpack](https://github.com/vmihailenco/msgpack) | `core/cache` codec |
 | `plugin/broker/sqs` | AWS SQS | `core/broker` |
 | `plugin/broker/sns` | AWS SNS | `core/broker` |
 | `plugin/broker/nats` | [NATS](https://nats.io) | `core/broker` |
@@ -80,7 +79,7 @@ This means your application code depends only on `core/` interfaces. Swap Redis 
 | `plugin/event/*` | Outbox, JetStream, HTTP | `core/event` |
 | `plugin/job/jorm` | GORM | `core/job` |
 | `plugin/cipher/bcrypt` | bcrypt | `core/cipher` |
-| `plugin/seal` | JWT (lestrrat-go/jwx) | `core/seal` |
+| `plugin/seal` | JWT (lestrrat-go/jwx) | Data sealing/signatures |
 | `plugin/txm/txmgorm` | GORM | `core/txm` |
 | `plugin/otel` | OpenTelemetry | Tracer/Meter helpers |
 | `plugin/restchi` | [Chi](https://github.com/go-chi/chi) | HTTP server |

--- a/core/audit/audit_test.go
+++ b/core/audit/audit_test.go
@@ -66,8 +66,7 @@ func (s *spyProvider) logs() []Log {
 
 func TestOrchestratorDispatchAndFlush_BatchSize(t *testing.T) {
 	spy := &spyProvider{}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	orch := NewOrchestrator(ctx,
 		WithBatchSize(2),
@@ -98,11 +97,10 @@ func TestOrchestratorDispatchAndFlush_BatchSize(t *testing.T) {
 
 func TestOrchestratorDispatchAndFlush_Interval(t *testing.T) {
 	spy := &spyProvider{}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	orch := NewOrchestrator(ctx,
-		WithBatchSize(100),                    // large batch so interval triggers first
+		WithBatchSize(100), // large batch so interval triggers first
 		WithBatchInterval(100*time.Millisecond),
 		WithProvider(spy),
 	)

--- a/core/broker/codec.go
+++ b/core/broker/codec.go
@@ -1,3 +1,4 @@
+// Package broker provides messaging abstractions for publishing and subscribing.
 package broker
 
 // Encoder is a function type that converts a Message into a byte slice.

--- a/core/cache/cache.go
+++ b/core/cache/cache.go
@@ -1,3 +1,4 @@
+// Package cache provides caching abstractions and utilities.
 package cache
 
 import (

--- a/core/cache/memory.go
+++ b/core/cache/memory.go
@@ -25,7 +25,7 @@ func (i *inMemoryCache) Set(ctx context.Context, item Item) error {
 
 	if item.ExpiresIn > 0 {
 		time.AfterFunc(item.ExpiresIn, func() {
-			_ = i.Delete(context.TODO(), item.Key)
+			_ = i.Delete(context.TODO(), item.Key) //nolint:errcheck
 		})
 	}
 

--- a/core/conf/convert.go
+++ b/core/conf/convert.go
@@ -1,3 +1,4 @@
+// Package conf provides configuration loading and conversion utilities.
 package conf
 
 import (

--- a/core/logger/std.go
+++ b/core/logger/std.go
@@ -33,11 +33,11 @@ func (cw *consoleWriter) Write(rank Level, content string, modifiers ...Option) 
 	for attr, val := range config.Attributes {
 		switch v := val.(type) {
 		case string:
-			sb.WriteString(fmt.Sprintf(" %s=%s", attr, v))
+			fmt.Fprintf(&sb, " %s=%s", attr, v)
 		case int, int8, int16, int32, int64:
-			sb.WriteString(fmt.Sprintf(" %s=%d", attr, v))
+			fmt.Fprintf(&sb, " %s=%d", attr, v)
 		case uint, uint8, uint16, uint32, uint64:
-			sb.WriteString(fmt.Sprintf(" %s=%d", attr, v))
+			fmt.Fprintf(&sb, " %s=%d", attr, v)
 		// TODO: Consider handling complex nested structures
 		default:
 			// Ignore unsupported types

--- a/core/repository/abstract.go
+++ b/core/repository/abstract.go
@@ -1,3 +1,4 @@
+// Package repository provides abstract repository patterns for data access.
 package repository
 
 import "context"

--- a/core/worker/abstract_worker.go
+++ b/core/worker/abstract_worker.go
@@ -1,3 +1,4 @@
+// Package worker provides abstractions for background worker management.
 package worker
 
 import (

--- a/plugin/broker/natsjetstream/event_transport.go
+++ b/plugin/broker/natsjetstream/event_transport.go
@@ -73,7 +73,7 @@ func (t *EventTransport) Publish(ctx context.Context, subject string, data []byt
 // Subscribe implements eventbroker.ConsumerTransport.
 func (t *EventTransport) Subscribe(
 	ctx context.Context,
-	cfg eventbroker.ConsumerSubscriptionConfig,
+	cfg *eventbroker.ConsumerSubscriptionConfig,
 	handler func(ctx context.Context, data []byte) error,
 ) (eventbroker.Subscription, error) {
 	maxDeliver := cfg.MaxDeliver
@@ -237,4 +237,3 @@ func (s *jsSubscription) Close() error {
 	defer s.closeMux.Unlock()
 	return s.closeErr
 }
-

--- a/plugin/broker/sns/client.go
+++ b/plugin/broker/sns/client.go
@@ -1,3 +1,4 @@
+// Package sns provides an AWS SNS broker implementation.
 package sns
 
 import (

--- a/plugin/broker/sqs/client.go
+++ b/plugin/broker/sqs/client.go
@@ -1,3 +1,4 @@
+// Package sqs provides an AWS SQS broker implementation.
 package sqs
 
 import (

--- a/plugin/broker/subscriber/handler.go
+++ b/plugin/broker/subscriber/handler.go
@@ -1,3 +1,4 @@
+// Package subscriber provides message subscription handling utilities.
 package subscriber
 
 import (

--- a/plugin/cache/msgpack/codec.go
+++ b/plugin/cache/msgpack/codec.go
@@ -1,3 +1,4 @@
+// Package msgpack provides MessagePack encoding and decoding for cache values.
 package msgpack
 
 import (

--- a/plugin/cache/redis/options.go
+++ b/plugin/cache/redis/options.go
@@ -77,7 +77,7 @@ func WithMinIdleConns(size uint) Option {
 // WithMaxIdleConns sets the maximum number of idle connections option.
 func WithMaxIdleConns(size uint) Option {
 	return func(o *options) {
-		o.redisOptions.MaxIdleConns = int(size)
+		o.redisOptions.MaxIdleConns = int(size) //nolint:gosec // small values
 	}
 }
 

--- a/plugin/conf/ssm/aws.go
+++ b/plugin/conf/ssm/aws.go
@@ -1,3 +1,4 @@
+// Package ssm provides configuration management using AWS Systems Manager Parameter Store.
 package ssm
 
 import (

--- a/plugin/event/eventbroker/consumer.go
+++ b/plugin/event/eventbroker/consumer.go
@@ -71,7 +71,7 @@ func NewConsumer(transport ConsumerTransport, cfg ConsumerConfig) (*Consumer, er
 		subCfg.FetchMaxWait = int(cfg.FetchMaxWait.Seconds())
 	}
 
-	sub, err := transport.Subscribe(context.Background(), subCfg, rawHandler)
+	sub, err := transport.Subscribe(context.Background(), &subCfg, rawHandler)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/event/eventbroker/transport.go
+++ b/plugin/event/eventbroker/transport.go
@@ -12,7 +12,7 @@ type Transport interface {
 type ConsumerTransport interface {
 	// Subscribe creates a subscription that delivers raw messages to the handler.
 	// The handler receives the raw bytes; deserialization is done by the caller.
-	Subscribe(ctx context.Context, cfg ConsumerSubscriptionConfig, handler func(ctx context.Context, data []byte) error) (Subscription, error)
+	Subscribe(ctx context.Context, cfg *ConsumerSubscriptionConfig, handler func(ctx context.Context, data []byte) error) (Subscription, error)
 }
 
 // ConsumerSubscriptionConfig carries the parameters needed to create a subscription.

--- a/plugin/logger/slogx/factory.go
+++ b/plugin/logger/slogx/factory.go
@@ -1,3 +1,4 @@
+// Package slogx provides a structured logging implementation using slog.
 package slogx
 
 import (

--- a/plugin/logger/zapx/factory.go
+++ b/plugin/logger/zapx/factory.go
@@ -1,3 +1,4 @@
+// Package zapx provides a structured logging implementation using zap.
 package zapx
 
 import (

--- a/plugin/rest/response.go
+++ b/plugin/rest/response.go
@@ -1,3 +1,4 @@
+// Package rest provides HTTP REST server utilities and response helpers.
 package rest
 
 import (

--- a/tests/e2e/eventbroker/eventbroker_test.go
+++ b/tests/e2e/eventbroker/eventbroker_test.go
@@ -33,7 +33,7 @@ func (m *memTransport) Publish(_ context.Context, subject string, data []byte) e
 	return nil
 }
 
-func (m *memTransport) get(i int) (string, []byte) {
+func (m *memTransport) get(i int) (subject string, data []byte) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.messages[i].Subject, m.messages[i].Data
@@ -50,8 +50,8 @@ type testMetadata struct {
 	UserID string `json:"user_id"`
 }
 
-func (t testMetadata) EventType() string  { return "USER_CREATED" }
-func (t testMetadata) EventVersion() int  { return 1 }
+func (t testMetadata) EventType() string { return "USER_CREATED" }
+func (t testMetadata) EventVersion() int { return 1 }
 
 func TestDispatcher_Dispatch(t *testing.T) {
 	transport := &memTransport{}
@@ -88,7 +88,7 @@ func TestDispatcher_MultipleEvents(t *testing.T) {
 	transport := &memTransport{}
 	dispatcher := eventbroker.NewDispatcher(transport, "events.multi")
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		record, err := event.NewRecord(testMetadata{UserID: "u-multi"})
 		require.NoError(t, err)
 		require.NoError(t, dispatcher.Dispatch(context.Background(), record))

--- a/tests/e2e/seal/seal_test.go
+++ b/tests/e2e/seal/seal_test.go
@@ -3,8 +3,6 @@ package seal_test
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -112,8 +110,7 @@ func TestSealUnsealNonceCheck(t *testing.T) {
 	// Second unseal with the same signature should fail with ErrUsedSignature.
 	_, err = svc.Unseal(ctx, &seal.UnsealInput{Signature: sealOut.Signature})
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, seal.ErrUsedSignature),
-		fmt.Sprintf("expected ErrUsedSignature, got: %v", err))
+	assert.ErrorIs(t, err, seal.ErrUsedSignature)
 }
 
 func TestSealUnsealExpired(t *testing.T) {
@@ -141,6 +138,5 @@ func TestSealUnsealExpired(t *testing.T) {
 	// Unseal should fail with ErrSealSignatureExpired.
 	_, err = svc.Unseal(ctx, &seal.UnsealInput{Signature: sealOut.Signature})
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, seal.ErrSealSignatureExpired),
-		fmt.Sprintf("expected ErrSealSignatureExpired, got: %v", err))
+	assert.ErrorIs(t, err, seal.ErrSealSignatureExpired)
 }

--- a/tests/integration/cache/redis_test.go
+++ b/tests/integration/cache/redis_test.go
@@ -18,7 +18,7 @@ func TestRedisProvider(t *testing.T) {
 	provider, err := redis.NewProvider(ctx,
 		redis.WithAddress("localhost:6379"),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer provider.Close(ctx)
 
 	tests := []struct {
@@ -42,7 +42,7 @@ func TestRedisProvider(t *testing.T) {
 			},
 			operation: func(t *testing.T) {
 				value, err := provider.Get(ctx, "test-key")
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, []byte("test-value"), value)
 			},
 			expectedError: nil,
@@ -133,10 +133,10 @@ func TestRedisProviderWithCache(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := c.Set(ctx, tt.item)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			err = c.Get(ctx, tt.item.Key, tt.decodeTo)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expectedValue, *tt.decodeTo)
 		})
 	}
@@ -148,7 +148,7 @@ func TestRedisProviderWithCacheResolver_Get(t *testing.T) {
 	provider, err := redis.NewProvider(ctx,
 		redis.WithAddress("localhost:6379"),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer provider.Close(ctx)
 
 	c := cache.New(provider,
@@ -205,7 +205,7 @@ func TestRedisProviderWithCacheResolver_Get(t *testing.T) {
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.expectedValue, result)
 			}
 		})
@@ -218,7 +218,7 @@ func TestRedisProviderWithCacheResolver(t *testing.T) {
 	provider, err := redis.NewProvider(ctx,
 		redis.WithAddress("localhost:6379"),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer provider.Close(ctx)
 
 	c := cache.New(provider,
@@ -247,7 +247,7 @@ func TestRedisProviderWithCacheResolver(t *testing.T) {
 					ExpiresIn: time.Minute,
 				}
 				err := c.Set(ctx, cItem)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				return cache.NewResolver("test-key",
 					cache.WithCache[Sample](c),
@@ -298,7 +298,7 @@ func TestRedisProviderWithCacheResolver(t *testing.T) {
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.expectedValue, result)
 			}
 		})


### PR DESCRIPTION
## Summary
- Updates README: removes `core/identity` and `core/seal` from tables, adds `plugin/cache/msgpack`, updates audit and seal descriptions
- Updates CHANGELOG with full breaking changes section documenting refactoring PRs #21-#26
- Fixes all 21 remaining golangci-lint issues:
  - Added package comments to 10+ packages (ST1000)
  - `fmt.Fprintf` instead of `WriteString(fmt.Sprintf(...))` (QF1012)
  - `gofmt` formatting on new files
  - `t.Context()` instead of `context.WithCancel` in tests (modernize)
  - `assert.ErrorIs` instead of `assert.True(errors.Is(...))` (testifylint)
  - `require.NoError` for error assertions (testifylint)
  - `for range N` instead of `for i := 0; i < N; i++` (intrange)
  - Pass large struct by pointer (gocritic)
  - Named return values (gocritic)
  - `//nolint` annotations for intentional suppressions (gosec, errcheck)

## Test plan
- [x] `golangci-lint run` reports 0 issues
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)