### PR TITLE
docs: update README and CHANGELOG with refactoring changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`pkg/common/request_context.go`** — Transport-agnostic `RequestContext` (RequestID, TraceID, SpanID) with context helpers.
+- **`plugin/cache/msgpack`** — MsgPack encoder/decoder codec for `core/cache` (moved from core to plugin).
+- **`plugin/event/eventbroker/transport.go`** — `Transport` and `ConsumerTransport` interfaces for decoupled event dispatching.
+- **`plugin/broker/natsjetstream/event_transport.go`** — NATS JetStream adapter implementing eventbroker transport interfaces.
+- **`tests/e2e/seal/`** — End-to-end tests with PostgreSQL testcontainer for seal/unseal flow.
+- **`tests/e2e/eventbroker/`** — End-to-end tests for event dispatching with in-memory transport.
+
+### Changed
+
+- **`core/audit`** — `Log` struct is now transport-agnostic: HTTP-specific fields (`Method`, `Endpoint`, `StatusCode`, `IP`, `Signature`) replaced with generic `Action` (string) and `Metadata` (map[string]any). Added `NewHTTPLog()` convenience constructor. **Breaking.**
+- **`plugin/seal`** — All types moved from `core/seal` into `plugin/seal/types.go`. Seal is now a self-contained plugin, not a core abstraction. **Breaking.**
+- **`plugin/event/eventbroker`** — Dispatcher and consumer now accept `Transport`/`ConsumerTransport` interfaces instead of hard-coded NATS JetStream dependency. **Breaking.**
+- **`plugin/event/publisher.go`** and **`plugin/event/outbox/publisher.go`** — Updated to use `common.RequestContext` instead of removed `ActivityContext`.
+
+### Removed
+
+- **`core/seal`** — Moved to `plugin/seal`. Too app-specific for core (embeds GORM Entity, niche use case). **Breaking.**
+- **`core/identity`** — Removed entirely. User profile model tied to multi-tenant SaaS pattern, not a general infrastructure concern. **Breaking.**
+- **`core/cache/codec_msgpack.go`** — Moved to `plugin/cache/msgpack`. External dependency doesn't belong in core. **Breaking** (import path changed).
+- **`pkg/common/activity.go`** — Removed `ActivityContext` (web-specific). Replaced by `RequestContext`. **Breaking.**
+
+---
+
+## [Initial] - 2026-03-27
+
+### Added (from initial migration)
+
 - **`pkg/common`** — Shared foundation types: `BaseError` with typed HTTP errors (`ErrResourceNotFound`, `ErrInternalServer`, `ErrConflict`, etc.), `FailureMode` classification, `Entity` base model with GORM integration and auto UUID, `MustValidateDependencies` for struct validation.
 - **`pkg/core/ptr`** — Generic pointer helpers: `New[T]`, `Now()`, `Safe[T]`.
 - **`core/audit`** — Batching audit log system with configurable providers and flush intervals.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This means your application code depends only on `core/` interfaces. Swap Redis 
 
 | Package | Description |
 |---------|-------------|
-| `pkg/common` | Base entity, typed HTTP errors, failure mode classification, dependency validation |
+| `pkg/common` | Base entity, typed HTTP errors, failure mode classification, request context, dependency validation |
 | `pkg/core/ptr` | Generic pointer helpers: `New[T]`, `Now()`, `Safe[T]` |
 
 ### Core Interfaces (`core/`)
@@ -45,7 +45,7 @@ This means your application code depends only on `core/` interfaces. Swap Redis 
 | Package | Description |
 |---------|-------------|
 | `core/logger` | Structured logging with severity levels and context propagation |
-| `core/cache` | Key-value caching with TTL, codecs (JSON, GZIP, MsgPack), and `Resolver[T]` for cache-or-fetch |
+| `core/cache` | Key-value caching with TTL, codecs (JSON, GZIP), and `Resolver[T]` for cache-or-fetch |
 | `core/broker` | Message publishing and subscribing with pluggable codecs |
 | `core/repository` | Generic `AbstractRepository[T]` and `AbstractPaginatedRepository[T, E]` |
 | `core/conf` | Configuration loading from multiple providers |
@@ -53,11 +53,9 @@ This means your application code depends only on `core/` interfaces. Swap Redis 
 | `core/idem` | Idempotency framework with Manager, Store, Locker, and generic `Handle[T]` |
 | `core/job` | Async job queue with Orchestrator, panic recovery, and graceful shutdown |
 | `core/worker` | Background worker with lifecycle hooks |
-| `core/audit` | Batching audit log system with configurable flush intervals |
+| `core/audit` | Transport-agnostic batching audit log system with generic payload |
 | `core/cipher` | Hashing and verification interface |
 | `core/featureflag` | Feature toggle service with caching and auto-sync |
-| `core/identity` | Request context identity with organization/role support |
-| `core/seal` | Data sealing via signatures with nonce-based replay protection |
 | `core/txm` | Transaction manager interface |
 
 ### Plugin Implementations (`plugin/`)
@@ -67,6 +65,7 @@ This means your application code depends only on `core/` interfaces. Swap Redis 
 | `plugin/logger/zapx` | [Zap](https://github.com/uber-go/zap) | `core/logger` |
 | `plugin/logger/slogx` | `log/slog` | `core/logger` |
 | `plugin/cache/redis` | [go-redis](https://github.com/redis/go-redis) | `core/cache` |
+| `plugin/cache/msgpack` | [msgpack](https://github.com/vmihailenco/msgpack) | `core/cache` codec |
 | `plugin/broker/sqs` | AWS SQS | `core/broker` |
 | `plugin/broker/sns` | AWS SNS | `core/broker` |
 | `plugin/broker/nats` | [NATS](https://nats.io) | `core/broker` |
@@ -80,7 +79,7 @@ This means your application code depends only on `core/` interfaces. Swap Redis 
 | `plugin/event/*` | Outbox, JetStream, HTTP | `core/event` |
 | `plugin/job/jorm` | GORM | `core/job` |
 | `plugin/cipher/bcrypt` | bcrypt | `core/cipher` |
-| `plugin/seal` | JWT (lestrrat-go/jwx) | `core/seal` |
+| `plugin/seal` | JWT (lestrrat-go/jwx) | Data sealing/signatures |
 | `plugin/txm/txmgorm` | GORM | `core/txm` |
 | `plugin/otel` | OpenTelemetry | Tracer/Meter helpers |
 | `plugin/restchi` | [Chi](https://github.com/go-chi/chi) | HTTP server |


### PR DESCRIPTION
## Summary
- Removes `core/identity` and `core/seal` from core interfaces table
- Adds `plugin/cache/msgpack` to plugin table
- Updates `core/audit` description to reflect generic payload
- Updates `plugin/seal` description (self-contained, not implementing a core interface)
- Updates `pkg/common` description to include request context
- Adds detailed CHANGELOG entries for all breaking changes from PRs #21-#26

🤖 Generated with [Claude Code](https://claude.ai/claude-code)