### PR TITLE
feat: add 1Password configuration provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`plugin/conf/onepassword`** — 1Password configuration provider using the official SDK, `op://` prefix resolution, and graceful noop fallback.
 - **`plugin/conf/vault`** — HashiCorp Vault configuration provider with KV v1/v2 support, `vault://` prefix resolution, inline mount path override, and graceful noop fallback.
 - **`pkg/common/request_context.go`** — Transport-agnostic `RequestContext` (RequestID, TraceID, SpanID) with context helpers.
 - **`plugin/cache/msgpack`** — MsgPack encoder/decoder codec for `core/cache` (moved from core to plugin).

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ This means your application code depends only on `core/` interfaces. Swap Redis 
 | `plugin/abstractrepo` | [GORM](https://gorm.io) | `core/repository` |
 | `plugin/conf/ssm` | AWS SSM Parameter Store | `core/conf` |
 | `plugin/conf/vault` | [HashiCorp Vault](https://www.vaultproject.io) | `core/conf` |
+| `plugin/conf/onepassword` | [1Password](https://1password.com) | `core/conf` |
 | `plugin/idem/gorm` | GORM/PostgreSQL | `core/idem` |
 | `plugin/idem/inmem` | In-memory | `core/idem` |
 | `plugin/idem/postgres` | PostgreSQL (raw SQL) | `core/idem` |

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 
 require (
 	dario.cat/mergo v1.0.2 // indirect
+	github.com/1password/onepassword-sdk-go v0.4.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
@@ -72,7 +73,9 @@ require (
 	github.com/docker/docker v28.5.2+incompatible // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
+	github.com/dylibso/observe-sdk/go v0.0.0-20240828172851-9145d8ad07e1 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
+	github.com/extism/go-sdk v1.7.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
@@ -81,6 +84,7 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -92,6 +96,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
+	github.com/ianlancetaylor/demangle v0.0.0-20251118225945-96ee0021ea0f // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.6.0 // indirect
@@ -127,12 +132,15 @@ require (
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.2 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834 // indirect
+	github.com/tetratelabs/wazero v1.11.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
+github.com/1password/onepassword-sdk-go v0.4.0 h1:Nou39yuC6Q0om03irkh5UurfPdX3wx26qZZhQeC9TBU=
+github.com/1password/onepassword-sdk-go v0.4.0/go.mod h1:j/CbzhucTywjlYrd6SE6k0LcQaFZ2l8OLBsAsOYtvD0=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
@@ -75,8 +77,12 @@ github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pM
 github.com/docker/go-connections v0.6.0/go.mod h1:AahvXYshr6JgfUJGdDCs2b5EZG/vmaMAntpSFH5BFKE=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dylibso/observe-sdk/go v0.0.0-20240828172851-9145d8ad07e1 h1:idfl8M8rPW93NehFw5H1qqH8yG158t5POr+LX9avbJY=
+github.com/dylibso/observe-sdk/go v0.0.0-20240828172851-9145d8ad07e1/go.mod h1:C8DzXehI4zAbrdlbtOByKX6pfivJTBiV9Jjqv56Yd9Q=
 github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/extism/go-sdk v1.7.1 h1:lWJos6uY+tRFdlIHR+SJjwFDApY7OypS/2nMhiVQ9Sw=
+github.com/extism/go-sdk v1.7.1/go.mod h1:IT+Xdg5AZM9hVtpFUA+uZCJMge/hbvshl8bwzLtFyKA=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -106,6 +112,8 @@ github.com/go-resty/resty/v2 v2.17.2 h1:FQW5oHYcIlkCNrMD2lloGScxcHJ0gkjshV3qcQAy
 github.com/go-resty/resty/v2 v2.17.2/go.mod h1:kCKZ3wWmwJaNc7S29BRtUhJwy7iqmn+2mLtQrOyQlVA=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/goccy/go-json v0.10.3 h1:KZ5WoDbxAIgm2HNbYckL0se1fHD6rz5j4ywS6ebzDqA=
 github.com/goccy/go-json v0.10.3/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -140,6 +148,8 @@ github.com/hashicorp/vault-client-go v0.4.3 h1:zG7STGVgn/VK6rnZc0k8PGbfv2x/sJExR
 github.com/hashicorp/vault-client-go v0.4.3/go.mod h1:4tDw7Uhq5XOxS1fO+oMtotHL7j4sB9cp0T7U6m4FzDY=
 github.com/hashicorp/vault/api v1.23.0 h1:gXgluBsSECfRWTSW9niY2jwg2e9mMJc4WoHNv4g3h6A=
 github.com/hashicorp/vault/api v1.23.0/go.mod h1:zransKiB9ftp+kgY8ydjnvCU7Wk8i9L0DYWpXeMj9ko=
+github.com/ianlancetaylor/demangle v0.0.0-20251118225945-96ee0021ea0f h1:Fnl4pzx8SR7k7JuzyW8lEtSFH6EQ8xgcypgIn8pcGIE=
+github.com/ianlancetaylor/demangle v0.0.0-20251118225945-96ee0021ea0f/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
@@ -256,6 +266,10 @@ github.com/testcontainers/testcontainers-go/modules/postgres v0.41.0 h1:AOtFXssr
 github.com/testcontainers/testcontainers-go/modules/postgres v0.41.0/go.mod h1:k2a09UKhgSp6vNpliIY0QSgm4Hi7GXVTzWvWgUemu/8=
 github.com/testcontainers/testcontainers-go/modules/vault v0.41.0 h1:Hx5n69IeJBhMkiQ7V3RBCq1iPUrWCv+KEwZCjoWRc3Y=
 github.com/testcontainers/testcontainers-go/modules/vault v0.41.0/go.mod h1:dEQvxqPf62AIxEzymv+rD8+4A5TIvTA0/Etoh7csZbE=
+github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834 h1:ZF+QBjOI+tILZjBaFj3HgFonKXUcwgJ4djLb6i42S3Q=
+github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834/go.mod h1:m9ymHTgNSEjuxvw8E7WWe4Pl4hZQHXONY8wE6dMLaRk=
+github.com/tetratelabs/wazero v1.11.0 h1:+gKemEuKCTevU4d7ZTzlsvgd1uaToIDtlQlmNbwqYhA=
+github.com/tetratelabs/wazero v1.11.0/go.mod h1:eV28rsN8Q+xwjogd7f4/Pp4xFxO7uOGbLcD/LzB1wiU=
 github.com/tidwall/gjson v1.17.1 h1:wlYEnwqAHgzmhNUFfw7Xalt2JzQvsMx2Se4PcoFCT/U=
 github.com/tidwall/gjson v1.17.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
@@ -292,6 +306,8 @@ go.opentelemetry.io/otel/trace v1.41.0 h1:Vbk2co6bhj8L59ZJ6/xFTskY+tGAbOnCtQGVVa
 go.opentelemetry.io/otel/trace v1.41.0/go.mod h1:U1NU4ULCoxeDKc09yCWdWe+3QoyweJcISEVa1RBzOis=
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
+go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjceRb/A=
+go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=

--- a/plugin/conf/onepassword/README.md
+++ b/plugin/conf/onepassword/README.md
@@ -1,0 +1,143 @@
+# 1Password Configuration Provider
+
+A `core/conf.Provider` implementation that resolves secrets from [1Password](https://1password.com) using the official SDK and service account authentication.
+
+## Prerequisites
+
+- [1Password CLI](https://developer.1password.com/docs/cli/get-started/) (`op`) installed
+- A 1Password account with access to create service accounts
+
+## Setup
+
+### 1. Create a vault
+
+```bash
+op vault create "my-app-secrets"
+```
+
+### 2. Add secrets to the vault
+
+```bash
+# Create an item with multiple fields
+op item create --vault "my-app-secrets" \
+  --category login \
+  --title "database" \
+  username=admin \
+  password=s3cret \
+  host=db.example.com
+
+# Create a single-field secret
+op item create --vault "my-app-secrets" \
+  --category "API Credential" \
+  --title "stripe" \
+  credential=sk_live_abc123
+```
+
+### 3. Create a service account
+
+```bash
+op service-account create "my-app-sa" \
+  --vault "my-app-secrets:read_items"
+```
+
+This outputs a service account token. Store it securely — you'll need it as `OP_SERVICE_ACCOUNT_TOKEN`.
+
+### 4. Set the environment variable
+
+```bash
+export OP_SERVICE_ACCOUNT_TOKEN="ops_..."
+```
+
+## Usage
+
+Reference secrets in your environment or config using the `op://` prefix:
+
+```
+op://vault-name/item-name/field-name
+```
+
+### Example
+
+```bash
+# Environment variables with 1Password references
+export DB_USER="op://my-app-secrets/database/username"
+export DB_PASS="op://my-app-secrets/database/password"
+export DB_HOST="op://my-app-secrets/database/host"
+export STRIPE_KEY="op://my-app-secrets/stripe/credential"
+export APP_ENV="production"  # plain values are left as-is
+```
+
+```go
+package main
+
+import (
+    "context"
+
+    "github.com/aawadallak/go-core-kit/core/conf"
+    op "github.com/aawadallak/go-core-kit/plugin/conf/onepassword"
+)
+
+func main() {
+    ctx := context.Background()
+
+    cfg := conf.New(
+        conf.WithProvider(op.NewProvider(ctx)),
+    )
+
+    // Resolved from 1Password
+    dbPass := cfg.GetString("DB_PASS")     // "s3cret"
+    stripeKey := cfg.GetString("STRIPE_KEY") // "sk_live_abc123"
+
+    // Plain value, untouched
+    appEnv := cfg.GetString("APP_ENV")     // "production"
+}
+```
+
+## How It Works
+
+1. During `Load()`, the provider scans all upstream providers (e.g., environment variables) for values prefixed with `op://`
+2. Each `op://vault/item/field` reference is resolved via the 1Password SDK's `Secrets().Resolve()` method
+3. The resolved plaintext value replaces the reference in the config
+4. Non-`op://` values are ignored and left for other providers to handle
+
+## Configuration
+
+| Environment Variable | Required | Default | Description |
+|---|---|---|---|
+| `OP_SERVICE_ACCOUNT_TOKEN` | Yes | — | 1Password service account token |
+
+If `OP_SERVICE_ACCOUNT_TOKEN` is not set, the provider silently falls back to a noop (returns no values, no errors). This allows the same code to run in environments without 1Password access.
+
+## Secret Reference Format
+
+```
+op://vault-name/item-name/field-name
+```
+
+| Segment | Description |
+|---------|-------------|
+| `vault-name` | Name of the 1Password vault |
+| `item-name` | Title of the item in the vault |
+| `field-name` | Specific field within the item |
+
+## Useful CLI Commands
+
+```bash
+# List vaults
+op vault list
+
+# List items in a vault
+op item list --vault "my-app-secrets"
+
+# Get a specific item
+op item get "database" --vault "my-app-secrets"
+
+# Read a specific field
+op read "op://my-app-secrets/database/password"
+
+# Delete an item
+op item delete "database" --vault "my-app-secrets"
+
+# Delete a vault
+op vault delete "my-app-secrets"
+```

--- a/plugin/conf/onepassword/noop.go
+++ b/plugin/conf/onepassword/noop.go
@@ -1,0 +1,15 @@
+package onepassword
+
+import (
+	"context"
+
+	"github.com/aawadallak/go-core-kit/core/conf"
+)
+
+type noopProvider struct{}
+
+var _ conf.Provider = (*noopProvider)(nil)
+
+func (n *noopProvider) Load(_ context.Context, _ []conf.Provider) error { return nil }
+func (n *noopProvider) Lookup(_ string) (string, bool)                  { return "", false }
+func (n *noopProvider) Scan(_ conf.ScanFunc)                            {}

--- a/plugin/conf/onepassword/provider.go
+++ b/plugin/conf/onepassword/provider.go
@@ -1,0 +1,81 @@
+// Package onepassword provides a 1Password configuration provider for core/conf.
+package onepassword
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/1password/onepassword-sdk-go"
+	"github.com/aawadallak/go-core-kit/core/conf"
+)
+
+const opPrefix = "op://"
+
+type provider struct {
+	data   map[string]string
+	client *onepassword.Client
+}
+
+var _ conf.Provider = (*provider)(nil)
+
+// NewProvider creates a 1Password configuration provider.
+// Returns a noop provider if OP_SERVICE_ACCOUNT_TOKEN is not set or client creation fails.
+func NewProvider(ctx context.Context) conf.Provider {
+	token := os.Getenv("OP_SERVICE_ACCOUNT_TOKEN")
+	if token == "" {
+		return &noopProvider{}
+	}
+	client, err := onepassword.NewClient(ctx,
+		onepassword.WithServiceAccountToken(token),
+		onepassword.WithIntegrationInfo("go-core-kit", "v1.0.0"),
+	)
+	if err != nil {
+		return &noopProvider{}
+	}
+	return &provider{client: client, data: make(map[string]string)}
+}
+
+func (p *provider) Lookup(key string) (string, bool) {
+	v, ok := p.data[key]
+	return v, ok
+}
+
+func (p *provider) Scan(fn conf.ScanFunc) {
+	for k, v := range p.data {
+		fn(k, v)
+	}
+}
+
+func (p *provider) Load(ctx context.Context, others []conf.Provider) error {
+	refs := findReferences(others)
+	var errs []error
+	for _, ref := range refs {
+		secret, err := p.client.Secrets().Resolve(ctx, ref.opRef)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to resolve 1password secret %s: %w", ref.opRef, err))
+			continue
+		}
+		p.data[ref.key] = secret
+	}
+	return errors.Join(errs...)
+}
+
+type opRef struct {
+	key   string // config key (e.g., "DB_PASS")
+	opRef string // full 1password reference (e.g., "op://vault/item/field")
+}
+
+func findReferences(others []conf.Provider) []opRef {
+	var refs []opRef
+	for _, other := range others {
+		other.Scan(func(key, value string) {
+			if strings.HasPrefix(value, opPrefix) {
+				refs = append(refs, opRef{key: key, opRef: value})
+			}
+		})
+	}
+	return refs
+}

--- a/plugin/conf/onepassword/provider_test.go
+++ b/plugin/conf/onepassword/provider_test.go
@@ -1,0 +1,72 @@
+package onepassword
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aawadallak/go-core-kit/core/conf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type envProvider struct {
+	data map[string]string
+}
+
+func (e *envProvider) Load(_ context.Context, _ []conf.Provider) error { return nil }
+func (e *envProvider) Lookup(key string) (string, bool) {
+	v, ok := e.data[key]
+	return v, ok
+}
+func (e *envProvider) Scan(fn conf.ScanFunc) {
+	for k, v := range e.data {
+		fn(k, v)
+	}
+}
+
+func TestFindReferences(t *testing.T) {
+	env := &envProvider{data: map[string]string{
+		"DB_PASS": "op://vault/db/password",
+		"DB_HOST": "localhost",
+		"API_KEY": "op://vault/api/key",
+	}}
+
+	refs := findReferences([]conf.Provider{env})
+	assert.Len(t, refs, 2)
+
+	refMap := make(map[string]string)
+	for _, r := range refs {
+		refMap[r.key] = r.opRef
+	}
+	assert.Equal(t, "op://vault/db/password", refMap["DB_PASS"])
+	assert.Equal(t, "op://vault/api/key", refMap["API_KEY"])
+}
+
+func TestNoopWhenNoToken(t *testing.T) {
+	t.Setenv("OP_SERVICE_ACCOUNT_TOKEN", "")
+
+	p := NewProvider(t.Context())
+	require.NoError(t, p.Load(t.Context(), nil))
+
+	_, ok := p.Lookup("anything")
+	assert.False(t, ok)
+}
+
+func TestProviderLookupAndScan(t *testing.T) {
+	// Test the data store mechanics with a manually constructed provider
+	p := &provider{data: map[string]string{
+		"DB_PASS": "secret123",
+		"API_KEY": "key456",
+	}}
+
+	val, ok := p.Lookup("DB_PASS")
+	assert.True(t, ok)
+	assert.Equal(t, "secret123", val)
+
+	_, ok = p.Lookup("MISSING")
+	assert.False(t, ok)
+
+	var scanned int
+	p.Scan(func(key, value string) { scanned++ })
+	assert.Equal(t, 2, scanned)
+}


### PR DESCRIPTION
## Summary
Adds `plugin/conf/onepassword` — a 1Password configuration provider implementing `core/conf.Provider`.

**Features:**
- Resolves `op://vault/item/field` prefixed values from upstream providers using the official 1Password SDK
- Authentication via `OP_SERVICE_ACCOUNT_TOKEN` environment variable
- Graceful noop fallback when token is not set or client creation fails
- Collects all resolution errors and returns them joined

**Files:**
- `plugin/conf/onepassword/provider.go` — Main provider (NewProvider, Load, Lookup, Scan)
- `plugin/conf/onepassword/noop.go` — Noop fallback
- `plugin/conf/onepassword/provider_test.go` — Unit tests (reference extraction, noop, lookup/scan)

## Test plan
- [x] `go test ./plugin/conf/onepassword/...` — 3 tests pass
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)