### PR TITLE
feat(conf): add GetXOrDefault methods to ValueMap

### DIFF
--- a/core/conf/factory.go
+++ b/core/conf/factory.go
@@ -52,6 +52,46 @@ func (v *valueMap) GetBytes(key string) []byte {
 	return []byte(value)
 }
 
+// GetIntOrDefault retrieves an integer value for the given key.
+// Returns the provided default value if the key is not found.
+func (v *valueMap) GetIntOrDefault(key string, defaultValue int) int {
+	value, ok := v.get(key)
+	if !ok {
+		return defaultValue
+	}
+	return convertToInt(value)
+}
+
+// GetBoolOrDefault retrieves a boolean value for the given key.
+// Returns the provided default value if the key is not found.
+func (v *valueMap) GetBoolOrDefault(key string, defaultValue bool) bool {
+	value, ok := v.get(key)
+	if !ok {
+		return defaultValue
+	}
+	return convertToBool(value)
+}
+
+// GetStringOrDefault retrieves a string value for the given key.
+// Returns the provided default value if the key is not found.
+func (v *valueMap) GetStringOrDefault(key string, defaultValue string) string {
+	value, ok := v.get(key)
+	if ok {
+		return value
+	}
+	return defaultValue
+}
+
+// GetBytesOrDefault retrieves a byte slice value for the given key.
+// Returns the provided default value if the key is not found.
+func (v *valueMap) GetBytesOrDefault(key string, defaultValue []byte) []byte {
+	value, ok := v.get(key)
+	if !ok {
+		return defaultValue
+	}
+	return []byte(value)
+}
+
 // MustGetInt retrieves an integer value for the given key.
 // Panics if the key is not found or the value cannot be converted to an integer.
 func (v *valueMap) MustGetInt(key string) int {

--- a/core/conf/factory.go
+++ b/core/conf/factory.go
@@ -74,7 +74,7 @@ func (v *valueMap) GetBoolOrDefault(key string, defaultValue bool) bool {
 
 // GetStringOrDefault retrieves a string value for the given key.
 // Returns the provided default value if the key is not found.
-func (v *valueMap) GetStringOrDefault(key string, defaultValue string) string {
+func (v *valueMap) GetStringOrDefault(key, defaultValue string) string {
 	value, ok := v.get(key)
 	if ok {
 		return value

--- a/core/conf/factory_test.go
+++ b/core/conf/factory_test.go
@@ -1,0 +1,299 @@
+package conf
+
+import (
+	"context"
+	"testing"
+)
+
+type stubProvider struct {
+	data map[string]string
+}
+
+func (s *stubProvider) Lookup(key string) (string, bool) {
+	v, ok := s.data[key]
+	return v, ok
+}
+
+func (s *stubProvider) Scan(fn ScanFunc) {
+	for k, v := range s.data {
+		fn(k, v)
+	}
+}
+
+func (s *stubProvider) Load(_ context.Context, _ []Provider) error {
+	return nil
+}
+
+func newTestValueMap(data map[string]string) ValueMap {
+	return &valueMap{
+		providers: []Provider{&stubProvider{data: data}},
+	}
+}
+
+var testData = map[string]string{
+	"APP_NAME": "myapp",
+	"PORT":     "8080",
+	"DEBUG":    "true",
+	"SECRET":   "abc123",
+	"INVALID":  "notanumber",
+}
+
+// --- GetString ---
+
+func TestGetString(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.GetString("APP_NAME"); got != "myapp" {
+		t.Errorf("got %q, want %q", got, "myapp")
+	}
+}
+
+func TestGetString_Missing(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.GetString("MISSING"); got != "" {
+		t.Errorf("got %q, want %q", got, "")
+	}
+}
+
+// --- GetInt ---
+
+func TestGetInt(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.GetInt("PORT"); got != 8080 {
+		t.Errorf("got %d, want %d", got, 8080)
+	}
+}
+
+func TestGetInt_Missing(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.GetInt("MISSING"); got != 0 {
+		t.Errorf("got %d, want %d", got, 0)
+	}
+}
+
+func TestGetInt_InvalidValue(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.GetInt("INVALID"); got != 0 {
+		t.Errorf("got %d, want %d", got, 0)
+	}
+}
+
+// --- GetBool ---
+
+func TestGetBool(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.GetBool("DEBUG"); got != true {
+		t.Errorf("got %v, want %v", got, true)
+	}
+}
+
+func TestGetBool_Missing(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.GetBool("MISSING"); got != false {
+		t.Errorf("got %v, want %v", got, false)
+	}
+}
+
+func TestGetBool_InvalidValue(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.GetBool("INVALID"); got != false {
+		t.Errorf("got %v, want %v", got, false)
+	}
+}
+
+// --- GetBytes ---
+
+func TestGetBytes(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.GetBytes("SECRET"); string(got) != "abc123" {
+		t.Errorf("got %q, want %q", got, "abc123")
+	}
+}
+
+func TestGetBytes_Missing(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.GetBytes("MISSING"); got != nil {
+		t.Errorf("got %v, want nil", got)
+	}
+}
+
+// --- GetStringOrDefault ---
+
+func TestGetStringOrDefault(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.GetStringOrDefault("APP_NAME", "fallback"); got != "myapp" {
+		t.Errorf("got %q, want %q", got, "myapp")
+	}
+}
+
+func TestGetStringOrDefault_Missing(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.GetStringOrDefault("MISSING", "fallback"); got != "fallback" {
+		t.Errorf("got %q, want %q", got, "fallback")
+	}
+}
+
+// --- GetIntOrDefault ---
+
+func TestGetIntOrDefault(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.GetIntOrDefault("PORT", 3000); got != 8080 {
+		t.Errorf("got %d, want %d", got, 8080)
+	}
+}
+
+func TestGetIntOrDefault_Missing(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.GetIntOrDefault("MISSING", 3000); got != 3000 {
+		t.Errorf("got %d, want %d", got, 3000)
+	}
+}
+
+// --- GetBoolOrDefault ---
+
+func TestGetBoolOrDefault(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.GetBoolOrDefault("DEBUG", false); got != true {
+		t.Errorf("got %v, want %v", got, true)
+	}
+}
+
+func TestGetBoolOrDefault_Missing(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.GetBoolOrDefault("MISSING", true); got != true {
+		t.Errorf("got %v, want %v", got, true)
+	}
+}
+
+// --- GetBytesOrDefault ---
+
+func TestGetBytesOrDefault(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.GetBytesOrDefault("SECRET", []byte("default")); string(got) != "abc123" {
+		t.Errorf("got %q, want %q", got, "abc123")
+	}
+}
+
+func TestGetBytesOrDefault_Missing(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.GetBytesOrDefault("MISSING", []byte("default")); string(got) != "default" {
+		t.Errorf("got %q, want %q", got, "default")
+	}
+}
+
+// --- MustGetString ---
+
+func TestMustGetString(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.MustGetString("APP_NAME"); got != "myapp" {
+		t.Errorf("got %q, want %q", got, "myapp")
+	}
+}
+
+func TestMustGetString_Panics(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic, got none")
+		}
+	}()
+	vm.MustGetString("MISSING")
+}
+
+// --- MustGetInt ---
+
+func TestMustGetInt(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.MustGetInt("PORT"); got != 8080 {
+		t.Errorf("got %d, want %d", got, 8080)
+	}
+}
+
+func TestMustGetInt_Panics(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic, got none")
+		}
+	}()
+	vm.MustGetInt("MISSING")
+}
+
+// --- MustGetBool ---
+
+func TestMustGetBool(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.MustGetBool("DEBUG"); got != true {
+		t.Errorf("got %v, want %v", got, true)
+	}
+}
+
+func TestMustGetBool_Panics(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic, got none")
+		}
+	}()
+	vm.MustGetBool("MISSING")
+}
+
+// --- MustGetBytes ---
+
+func TestMustGetBytes(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	if got := vm.MustGetBytes("SECRET"); string(got) != "abc123" {
+		t.Errorf("got %q, want %q", got, "abc123")
+	}
+}
+
+func TestMustGetBytes_Panics(t *testing.T) {
+	vm := newTestValueMap(testData)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic, got none")
+		}
+	}()
+	vm.MustGetBytes("MISSING")
+}
+
+// --- Multiple providers (priority) ---
+
+func TestMultipleProviders_FirstWins(t *testing.T) {
+	primary := &stubProvider{data: map[string]string{"KEY": "primary"}}
+	fallback := &stubProvider{data: map[string]string{"KEY": "fallback", "ONLY_FALLBACK": "yes"}}
+
+	vm := &valueMap{providers: []Provider{primary, fallback}}
+
+	if got := vm.GetString("KEY"); got != "primary" {
+		t.Errorf("got %q, want %q", got, "primary")
+	}
+	if got := vm.GetString("ONLY_FALLBACK"); got != "yes" {
+		t.Errorf("got %q, want %q", got, "yes")
+	}
+}

--- a/core/conf/interface.go
+++ b/core/conf/interface.go
@@ -25,6 +25,22 @@ type ValueMap interface {
 	// Returns nil if the key doesn't exist.
 	GetBytes(key string) []byte
 
+	// GetIntOrDefault returns the integer value associated with the specified key.
+	// Returns the provided default value if the key doesn't exist.
+	GetIntOrDefault(key string, defaultValue int) int
+
+	// GetBoolOrDefault returns the boolean value associated with the specified key.
+	// Returns the provided default value if the key doesn't exist.
+	GetBoolOrDefault(key string, defaultValue bool) bool
+
+	// GetStringOrDefault returns the string value associated with the specified key.
+	// Returns the provided default value if the key doesn't exist.
+	GetStringOrDefault(key string, defaultValue string) string
+
+	// GetBytesOrDefault returns the byte slice value associated with the specified key.
+	// Returns the provided default value if the key doesn't exist.
+	GetBytesOrDefault(key string, defaultValue []byte) []byte
+
 	// MustGetInt returns the integer value for the specified key.
 	// Panics if the key doesn't exist or if conversion to integer fails.
 	MustGetInt(key string) int


### PR DESCRIPTION
## Summary
- Add `GetStringOrDefault`, `GetIntOrDefault`, `GetBoolOrDefault`, and `GetBytesOrDefault` methods to the `ValueMap` interface and implementation
- Allows callers to specify a fallback value when a config/env key is missing, complementing the existing `GetX` (zero value) and `MustGetX` (panic) tiers
- Add comprehensive test coverage for all `ValueMap` methods (Get, GetOrDefault, MustGet) including missing keys, invalid values, panic behavior, and multi-provider priority

## Test plan
- [x] All 26 unit tests pass (`go test ./core/conf/...`)
- [x] Full project builds cleanly (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)