### PR TITLE
feat(cipher): add argon2id password hashing plugin

### DIFF
--- a/plugin/cipher/argon2/factory.go
+++ b/plugin/cipher/argon2/factory.go
@@ -113,7 +113,8 @@ func (a *Adapter) Verify(hashedValue []byte, value string) error {
 		return fmt.Errorf("argon2: decode hash: %w", err)
 	}
 
-	computed := argon2.IDKey([]byte(value), salt, time, memory, threads, uint32(len(expectedHash)))
+	keyLen := uint32(len(expectedHash)) //nolint:gosec // hash length is bounded by argon2 output, no overflow risk
+	computed := argon2.IDKey([]byte(value), salt, time, memory, threads, keyLen)
 
 	if subtle.ConstantTimeCompare(computed, expectedHash) != 1 {
 		return cipher.NewErrInvalidHash()

--- a/plugin/cipher/argon2/factory.go
+++ b/plugin/cipher/argon2/factory.go
@@ -1,0 +1,132 @@
+// Package argon2 provides argon2id password hashing functionality.
+package argon2
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+
+	"github.com/aawadallak/go-core-kit/core/cipher"
+
+	"golang.org/x/crypto/argon2"
+)
+
+const (
+	defaultTime    = 1
+	defaultMemory  = 64 * 1024
+	defaultThreads = 4
+	defaultKeyLen  = 32
+	defaultSaltLen = 16
+)
+
+type Option func(*Adapter)
+
+func WithTime(t uint32) Option {
+	return func(a *Adapter) { a.time = t }
+}
+
+func WithMemory(m uint32) Option {
+	return func(a *Adapter) { a.memory = m }
+}
+
+func WithThreads(t uint8) Option {
+	return func(a *Adapter) { a.threads = t }
+}
+
+func WithKeyLen(k uint32) Option {
+	return func(a *Adapter) { a.keyLen = k }
+}
+
+type Adapter struct {
+	time    uint32
+	memory  uint32
+	threads uint8
+	keyLen  uint32
+	saltLen int
+}
+
+func NewAdapter(opts ...Option) cipher.Cipher {
+	a := &Adapter{
+		time:    defaultTime,
+		memory:  defaultMemory,
+		threads: defaultThreads,
+		keyLen:  defaultKeyLen,
+		saltLen: defaultSaltLen,
+	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
+}
+
+func (a *Adapter) Encrypt(value string) ([]byte, error) {
+	salt := make([]byte, a.saltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return nil, fmt.Errorf("argon2: generate salt: %w", err)
+	}
+
+	hash := argon2.IDKey([]byte(value), salt, a.time, a.memory, a.threads, a.keyLen)
+
+	encoded := fmt.Sprintf(
+		"$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+		argon2.Version,
+		a.memory, a.time, a.threads,
+		base64.RawStdEncoding.EncodeToString(salt),
+		base64.RawStdEncoding.EncodeToString(hash),
+	)
+
+	return []byte(encoded), nil
+}
+
+func (a *Adapter) Verify(hashedValue []byte, value string) error {
+	var version int
+	var memory, time uint32
+	var threads uint8
+	var saltB64, hashB64 string
+
+	n, err := fmt.Sscanf(
+		string(hashedValue),
+		"$argon2id$v=%d$m=%d,t=%d,p=%d$%s",
+		&version, &memory, &time, &threads, &saltB64,
+	)
+	if err != nil || n != 5 {
+		return errors.New("argon2: invalid hash format")
+	}
+
+	// saltB64 contains "salt$hash", split on $
+	parts := splitLast(saltB64, '$')
+	if parts == nil {
+		return errors.New("argon2: invalid hash format")
+	}
+	saltB64 = parts[0]
+	hashB64 = parts[1]
+
+	salt, err := base64.RawStdEncoding.DecodeString(saltB64)
+	if err != nil {
+		return fmt.Errorf("argon2: decode salt: %w", err)
+	}
+
+	expectedHash, err := base64.RawStdEncoding.DecodeString(hashB64)
+	if err != nil {
+		return fmt.Errorf("argon2: decode hash: %w", err)
+	}
+
+	computed := argon2.IDKey([]byte(value), salt, time, memory, threads, uint32(len(expectedHash)))
+
+	if subtle.ConstantTimeCompare(computed, expectedHash) != 1 {
+		return cipher.NewErrInvalidHash()
+	}
+
+	return nil
+}
+
+func splitLast(s string, sep byte) []string {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == sep {
+			return []string{s[:i], s[i+1:]}
+		}
+	}
+	return nil
+}

--- a/plugin/cipher/argon2/factory_test.go
+++ b/plugin/cipher/argon2/factory_test.go
@@ -1,0 +1,94 @@
+package argon2
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aawadallak/go-core-kit/core/cipher"
+)
+
+func TestEncrypt(t *testing.T) {
+	a := NewAdapter()
+
+	hash, err := a.Encrypt("password123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.HasPrefix(string(hash), "$argon2id$") {
+		t.Errorf("hash should start with $argon2id$, got %q", hash)
+	}
+}
+
+func TestEncrypt_DifferentSalts(t *testing.T) {
+	a := NewAdapter()
+
+	hash1, _ := a.Encrypt("password123")
+	hash2, _ := a.Encrypt("password123")
+
+	if string(hash1) == string(hash2) {
+		t.Error("two hashes of the same password should differ due to random salt")
+	}
+}
+
+func TestVerify_CorrectPassword(t *testing.T) {
+	a := NewAdapter()
+
+	hash, err := a.Encrypt("password123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := a.Verify(hash, "password123"); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+}
+
+func TestVerify_WrongPassword(t *testing.T) {
+	a := NewAdapter()
+
+	hash, err := a.Encrypt("password123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	err = a.Verify(hash, "wrongpassword")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, cipher.ErrInvalidHash) {
+		t.Errorf("expected ErrInvalidHash, got %v", err)
+	}
+}
+
+func TestVerify_InvalidHashFormat(t *testing.T) {
+	a := NewAdapter()
+
+	err := a.Verify([]byte("not-a-valid-hash"), "password123")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestNewAdapter_WithOptions(t *testing.T) {
+	a := NewAdapter(
+		WithTime(2),
+		WithMemory(32*1024),
+		WithThreads(2),
+		WithKeyLen(64),
+	)
+
+	hash, err := a.Encrypt("password123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := a.Verify(hash, "password123"); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+}
+
+func TestAdapter_ImplementsCipherInterface(t *testing.T) {
+	var _ cipher.Cipher = NewAdapter()
+}

--- a/plugin/cipher/argon2/factory_test.go
+++ b/plugin/cipher/argon2/factory_test.go
@@ -1,6 +1,7 @@
 package argon2
 
 import (
+	"bytes"
 	"errors"
 	"strings"
 	"testing"
@@ -27,7 +28,7 @@ func TestEncrypt_DifferentSalts(t *testing.T) {
 	hash1, _ := a.Encrypt("password123")
 	hash2, _ := a.Encrypt("password123")
 
-	if string(hash1) == string(hash2) {
+	if bytes.Equal(hash1, hash2) {
 		t.Error("two hashes of the same password should differ due to random salt")
 	}
 }
@@ -90,5 +91,5 @@ func TestNewAdapter_WithOptions(t *testing.T) {
 }
 
 func TestAdapter_ImplementsCipherInterface(t *testing.T) {
-	var _ cipher.Cipher = NewAdapter()
+	_ = NewAdapter()
 }


### PR DESCRIPTION
## Summary
- Add `plugin/cipher/argon2` implementing the `cipher.Cipher` interface using argon2id
- Follows the same adapter pattern as `plugin/cipher/bcrypt`
- Supports functional options: `WithTime`, `WithMemory`, `WithThreads`, `WithKeyLen`
- Uses `crypto/subtle.ConstantTimeCompare` for timing-safe verification
- Encodes hashes in the standard `$argon2id$v=19$m=...,t=...,p=...$salt$hash` format

## Usage
```go
// Default settings
c := argon2.NewAdapter()

// Custom settings
c := argon2.NewAdapter(
    argon2.WithTime(2),
    argon2.WithMemory(128*1024),
    argon2.WithThreads(4),
    argon2.WithKeyLen(64),
)

hash, err := c.Encrypt("password")
err = c.Verify(hash, "password")
```

## Test plan
- [x] 7 unit tests covering encrypt, verify, wrong password, invalid format, custom options, and interface compliance
- [x] Full project builds cleanly (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)